### PR TITLE
fix info command error

### DIFF
--- a/lib/discord/api/v8/raw.ex
+++ b/lib/discord/api/v8/raw.ex
@@ -42,9 +42,11 @@ defmodule Discord.Api.V8.Raw do
 
   @impl Behavior
   def get_guild(guild_id, with_counts \\ false) do
-    {200, body} = get_guild_with_status_code(guild_id, with_counts)
-
-    body
+    # FIXME: First aid
+    case get_guild_with_status_code(guild_id, with_counts) do
+      {200, body} -> body
+      _ -> nil
+    end
   end
 
   @impl Behavior

--- a/lib/virtualCrypto_web/views/api/interactions_view/info.ex
+++ b/lib/virtualCrypto_web/views/api/interactions_view/info.ex
@@ -19,7 +19,7 @@ defmodule VirtualCryptoWeb.Api.InteractionsView.Info do
 
   def render_guild(guild) do
     case guild do
-      nil -> "不明\n"
+      nil -> "発行元サーバーの情報の取得に失敗しました。\n"
       guild -> ~s/発行元サーバー: #{guild["name"]}\n/
     end
   end


### PR DESCRIPTION
```
Apr 12 07:55:52 ip-172-26-4-70 mix[1494369]: ** (exit) an exception was raised:
Apr 12 07:55:52 ip-172-26-4-70 mix[1494369]:     ** (MatchError) no match of right hand side value: {403, %{"code" => 50001, "message" => "Missing Access"}}
Apr 12 07:55:52 ip-172-26-4-70 mix[1494369]:         (virtualCrypto 0.1.0) lib/discord/api/v8/raw.ex:45: Discord.Api.V8.Raw.get_guild/2
Apr 12 07:55:52 ip-172-26-4-70 mix[1494369]:         (virtualCrypto 0.1.0) lib/virtualCrypto_web/command_handler.ex:137: VirtualCryptoWeb.CommandHandler.handle/4
Apr 12 07:55:52 ip-172-26-4-70 mix[1494369]:         (virtualCrypto 0.1.0) lib/virtualCrypto_web/controllers/api/interactions_controller.ex:71: VirtualCryptoWeb.Api.InteractionsController.verified/2
Apr 12 07:55:52 ip-172-26-4-70 mix[1494369]:         (virtualCrypto 0.1.0) lib/virtualCrypto_web/controllers/api/interactions_controller.ex:1: VirtualCryptoWeb.Api.InteractionsController.action/2
Apr 12 07:55:52 ip-172-26-4-70 mix[1494369]:         (virtualCrypto 0.1.0) lib/virtualCrypto_web/controllers/api/interactions_controller.ex:1: VirtualCryptoWeb.Api.InteractionsController.phoenix_controller_pipeline/2
Apr 12 07:55:52 ip-172-26-4-70 mix[1494369]:         (phoenix 1.5.7) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
Apr 12 07:55:52 ip-172-26-4-70 mix[1494369]:         (virtualCrypto 0.1.0) lib/virtualCrypto_web/endpoint.ex:1: VirtualCryptoWeb.Endpoint.plug_builder_call/2
Apr 12 07:55:52 ip-172-26-4-70 mix[1494369]:         (virtualCrypto 0.1.0) lib/virtualCrypto_web/endpoint.ex:1: VirtualCryptoWeb.Endpoint.call/2
```